### PR TITLE
Return a path for single-digit oids

### DIFF
--- a/lib/partridge.rb
+++ b/lib/partridge.rb
@@ -7,7 +7,7 @@ module Partridge
   # Takes an oid and returns a string representing a pairtree path
   class Pairtree
     def self.oid_to_pairtree(oid)
-      formatted_oid = format('%02d', oid)
+      formatted_oid = format('%<number>02d', number: oid)
       prefix = formatted_oid[-2..-1]
       digest_path_structure = oid.to_s.scan(/../)
       digest_path_structure.each do |oiddir|

--- a/lib/partridge.rb
+++ b/lib/partridge.rb
@@ -7,7 +7,8 @@ module Partridge
   # Takes an oid and returns a string representing a pairtree path
   class Pairtree
     def self.oid_to_pairtree(oid)
-      prefix = oid.to_s[-2..-1]
+      formatted_oid = format('%02d', oid)
+      prefix = formatted_oid[-2..-1]
       digest_path_structure = oid.to_s.scan(/../)
       digest_path_structure.each do |oiddir|
         prefix += "/#{oiddir}"

--- a/spec/partridge_spec.rb
+++ b/spec/partridge_spec.rb
@@ -20,4 +20,9 @@ RSpec.describe Partridge::Pairtree do
     expect(described_class.oid_to_pairtree(1_234_567_890)).to eq('90/12/34/56/78/90')
     expect(described_class.oid_to_pairtree(1_014_543)).to eq('43/10/14/54')
   end
+
+  it 'returns a pair tree for single-digit oids' do
+    expect(described_class.oid_to_pairtree(3)).not_to eq nil
+    expect(described_class.oid_to_pairtree(3)).to eq '03'
+  end
 end


### PR DESCRIPTION
Previously, this gem was returning nil for single-digit oids, causing errors in applications using it. 

Connected to https://github.com/yalelibrary/YUL-DC/issues/827